### PR TITLE
fix: 아티스트 구독 시 응답 스키마 변경

### DIFF
--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/response/ArtistIdsApiResponse.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/response/ArtistIdsApiResponse.java
@@ -1,0 +1,18 @@
+package com.example.artist.controller.dto.response;
+
+import com.example.artist.service.dto.response.ArtistIdsServiceResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+public record ArtistIdsApiResponse(
+    @Schema(description = "아티스트 ID")
+    UUID id,
+
+    @Schema(description = "아티스트의 스포티파이 ID")
+    String artistSpotifyId
+) {
+
+    public static ArtistIdsApiResponse from(ArtistIdsServiceResponse response) {
+        return new ArtistIdsApiResponse(response.id(), response.artistSpotifyId());
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/response/ArtistSubscriptionApiResponse.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/response/ArtistSubscriptionApiResponse.java
@@ -3,15 +3,17 @@ package com.example.artist.controller.dto.response;
 import com.example.artist.service.dto.response.ArtistSubscriptionServiceResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import java.util.UUID;
 
 public record ArtistSubscriptionApiResponse(
-
-    @Schema(description = "구독 성공한 아티스트 ID")
-    List<UUID> successSubscriptionArtistIds
+    @Schema(description = "구독한 아티스트 아이디 목록")
+    List<ArtistIdsApiResponse> subscriptionArtistIds
 ) {
 
     public static ArtistSubscriptionApiResponse from(ArtistSubscriptionServiceResponse response) {
-        return new ArtistSubscriptionApiResponse(response.successSubscriptionArtistIds());
+        return new ArtistSubscriptionApiResponse(response.subscriptionArtistIds()
+            .stream()
+            .map(ArtistIdsApiResponse::from)
+            .toList()
+        );
     }
 }

--- a/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
@@ -8,6 +8,7 @@ import com.example.artist.service.dto.request.ArtistSubscriptionPaginationServic
 import com.example.artist.service.dto.request.ArtistSubscriptionServiceRequest;
 import com.example.artist.service.dto.request.ArtistUnsubscriptionPaginationServiceRequest;
 import com.example.artist.service.dto.request.ArtistUnsubscriptionServiceRequest;
+import com.example.artist.service.dto.response.ArtistIdsServiceResponse;
 import com.example.artist.service.dto.response.ArtistSubscriptionServiceResponse;
 import com.example.artist.service.dto.response.ArtistUnsubscriptionServiceResponse;
 import com.example.artist.service.dto.response.NumberOfSubscribedArtistServiceResponse;
@@ -91,9 +92,10 @@ public class ArtistService {
         );
 
         return ArtistSubscriptionServiceResponse.builder()
-            .successSubscriptionArtistIds(
-                subscribedArtistMessage.stream()
-                    .map(ArtistServiceMessage::id)
+            .subscriptionArtistIds(
+                requestArtist.stream()
+                    .filter(artist -> subscribedArtistIds.contains(artist.getId()))
+                    .map(ArtistIdsServiceResponse::from)
                     .toList()
             ).build();
     }

--- a/app/api/show-api/src/main/java/com/example/artist/service/dto/response/ArtistIdsServiceResponse.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/dto/response/ArtistIdsServiceResponse.java
@@ -1,0 +1,14 @@
+package com.example.artist.service.dto.response;
+
+import java.util.UUID;
+import org.example.entity.artist.Artist;
+
+public record ArtistIdsServiceResponse(
+    UUID id,
+    String artistSpotifyId
+) {
+
+    public static ArtistIdsServiceResponse from(Artist artist) {
+        return new ArtistIdsServiceResponse(artist.getId(), artist.getSpotifyId());
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/artist/service/dto/response/ArtistSubscriptionServiceResponse.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/dto/response/ArtistSubscriptionServiceResponse.java
@@ -1,12 +1,11 @@
 package com.example.artist.service.dto.response;
 
 import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record ArtistSubscriptionServiceResponse(
-    List<UUID> successSubscriptionArtistIds
+    List<ArtistIdsServiceResponse> subscriptionArtistIds
 ) {
 
 }

--- a/app/api/show-api/src/test/java/artist/fixture/dto/ArtistResponseDtoFixture.java
+++ b/app/api/show-api/src/test/java/artist/fixture/dto/ArtistResponseDtoFixture.java
@@ -39,7 +39,10 @@ public class ArtistResponseDtoFixture {
             .toList();
     }
 
-    public static ArtistSearchPaginationDomainResponse artistSearchPaginationDomainResponse(int limit, boolean hasNext) {
+    public static ArtistSearchPaginationDomainResponse artistSearchPaginationDomainResponse(
+        int limit,
+        boolean hasNext
+    ) {
         return ArtistSearchPaginationDomainResponse.builder()
             .data(artistSearchSimpleDomainResponses(limit))
             .limit(limit)
@@ -49,7 +52,9 @@ public class ArtistResponseDtoFixture {
 
     }
 
-    public static List<ArtistSearchSimpleDomainResponse> artistSearchSimpleDomainResponses(int size) {
+    public static List<ArtistSearchSimpleDomainResponse> artistSearchSimpleDomainResponses(
+        int size
+    ) {
         return IntStream.range(0, size)
             .mapToObj(i -> ArtistSearchSimpleDomainResponse.builder()
                 .id(UUID.randomUUID())

--- a/app/api/show-api/src/test/java/artist/fixture/dto/ArtistResponseDtoFixture.java
+++ b/app/api/show-api/src/test/java/artist/fixture/dto/ArtistResponseDtoFixture.java
@@ -3,6 +3,7 @@ package artist.fixture.dto;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.example.dto.artist.response.ArtistPaginationDomainResponse;
 import org.example.dto.artist.response.ArtistSearchPaginationDomainResponse;
 import org.example.dto.artist.response.ArtistSearchSimpleDomainResponse;
@@ -55,14 +56,12 @@ public class ArtistResponseDtoFixture {
     public static List<ArtistSearchSimpleDomainResponse> artistSearchSimpleDomainResponses(
         int size
     ) {
-        return IntStream.range(0, size)
-            .mapToObj(i -> ArtistSearchSimpleDomainResponse.builder()
+        return Stream.generate(() -> ArtistSearchSimpleDomainResponse.builder()
                 .id(UUID.randomUUID())
-                .name(i + "name")
-                .image(i + "testImage")
-                .name(i + "name")
-                .build()
-            )
+                .name("name")
+                .image("testImage")
+                .build())
+            .limit(size)
             .toList();
     }
 }

--- a/app/api/show-api/src/test/java/artist/fixture/dto/ArtistResponseDtoFixture.java
+++ b/app/api/show-api/src/test/java/artist/fixture/dto/ArtistResponseDtoFixture.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import org.example.dto.artist.response.ArtistPaginationDomainResponse;
+import org.example.dto.artist.response.ArtistSearchPaginationDomainResponse;
+import org.example.dto.artist.response.ArtistSearchSimpleDomainResponse;
 import org.example.dto.artist.response.ArtistSimpleDomainResponse;
 
 public class ArtistResponseDtoFixture {
@@ -34,6 +36,28 @@ public class ArtistResponseDtoFixture {
                 .name(i + "name")
                 .image(i + "testImage")
                 .build())
+            .toList();
+    }
+
+    public static ArtistSearchPaginationDomainResponse artistSearchPaginationDomainResponse(int limit, boolean hasNext) {
+        return ArtistSearchPaginationDomainResponse.builder()
+            .data(artistSearchSimpleDomainResponses(limit))
+            .limit(limit)
+            .offset(0)
+            .hasNext(hasNext)
+            .build();
+
+    }
+
+    public static List<ArtistSearchSimpleDomainResponse> artistSearchSimpleDomainResponses(int size) {
+        return IntStream.range(0, size)
+            .mapToObj(i -> ArtistSearchSimpleDomainResponse.builder()
+                .id(UUID.randomUUID())
+                .name(i + "name")
+                .image(i + "testImage")
+                .name(i + "name")
+                .build()
+            )
             .toList();
     }
 }

--- a/app/api/show-api/src/test/java/artist/service/ArtistServiceTest.java
+++ b/app/api/show-api/src/test/java/artist/service/ArtistServiceTest.java
@@ -25,7 +25,6 @@ import org.example.fixture.domain.ArtistSubscriptionFixture;
 import org.example.usecase.ArtistSubscriptionUseCase;
 import org.example.usecase.ArtistUseCase;
 import org.example.usecase.UserUseCase;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -56,9 +55,9 @@ class ArtistServiceTest {
         given(
             artistUseCase.searchArtist(request.toDomainRequest())
         )
-        .willReturn(
-            ArtistResponseDtoFixture.artistSearchPaginationDomainResponse(size, hasNext)
-        );
+            .willReturn(
+                ArtistResponseDtoFixture.artistSearchPaginationDomainResponse(size, hasNext)
+            );
 
         //when
         var result = artistService.searchArtist(request);
@@ -82,9 +81,9 @@ class ArtistServiceTest {
         given(
             artistUseCase.searchArtist(request.toDomainRequest())
         )
-        .willReturn(
-            ArtistResponseDtoFixture.artistSearchPaginationDomainResponse(0, false)
-        );
+            .willReturn(
+                ArtistResponseDtoFixture.artistSearchPaginationDomainResponse(0, false)
+            );
 
         //when
         var result = artistService.searchArtist(request);

--- a/app/api/show-api/src/test/java/artist/service/ArtistServiceTest.java
+++ b/app/api/show-api/src/test/java/artist/service/ArtistServiceTest.java
@@ -45,7 +45,6 @@ class ArtistServiceTest {
         messagePublisher
     );
 
-    @Disabled
     @Test
     @DisplayName("페이지네이션을 이용해 아티스트를 검색할 수 있다.")
     void artistSearchWithPagination() {
@@ -54,6 +53,12 @@ class ArtistServiceTest {
         int size = 3;
         boolean hasNext = true;
         var request = ArtistRequestDtoFixture.artistSearchPaginationServiceRequest(size, search);
+        given(
+            artistUseCase.searchArtist(request.toDomainRequest())
+        )
+        .willReturn(
+            ArtistResponseDtoFixture.artistSearchPaginationDomainResponse(size, hasNext)
+        );
 
         //when
         var result = artistService.searchArtist(request);
@@ -67,7 +72,6 @@ class ArtistServiceTest {
         );
     }
 
-    @Disabled
     @Test
     @DisplayName("아티스트 검색 결과가 없으면 빈 리스트를 반환한다.")
     void artistSearchEmptyResultWithPagination() {
@@ -75,6 +79,12 @@ class ArtistServiceTest {
         String search = "testArtistName";
         int size = 3;
         var request = ArtistRequestDtoFixture.artistSearchPaginationServiceRequest(size, search);
+        given(
+            artistUseCase.searchArtist(request.toDomainRequest())
+        )
+        .willReturn(
+            ArtistResponseDtoFixture.artistSearchPaginationDomainResponse(0, false)
+        );
 
         //when
         var result = artistService.searchArtist(request);
@@ -192,7 +202,7 @@ class ArtistServiceTest {
         SoftAssertions.assertSoftly(
             soft -> {
                 soft.assertThat(result).isNotNull();
-                soft.assertThat(result.successSubscriptionArtistIds().size())
+                soft.assertThat(result.subscriptionArtistIds().size())
                     .isEqualTo(existArtistsInRequest.size());
             }
         );


### PR DESCRIPTION
## 😋 작업한 내용

- 아티스트 구독 시 응답 스키마 변경 
- 기존 아티스트 자체 아이디로는 클라에서 검색 후 데이터 비교가 어려움
- 따라서, 클라이언트에서 아티스트 검색 후 데이터 비교를 위한 아티스트 자체 아이디 + spotifyId를 반환

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #13


---