### PR TITLE
refactor: 어드민 페이지 로그인 기능 추가

### DIFF
--- a/app/api/build.gradle
+++ b/app/api/build.gradle
@@ -13,6 +13,7 @@ allprojects {
         // thymeleaf
         implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
         implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.3.0'
+        implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
         implementation "org.springframework.boot:spring-boot-starter-web"
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
+++ b/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
@@ -9,10 +9,14 @@ import org.example.filter.JWTFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -33,9 +37,21 @@ public class SecurityConfig {
         return http
             .csrf(AbstractHttpConfigurer::disable)
             .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
+            .formLogin((formLogin) -> formLogin
+                .loginPage("/admin/login")
+                .usernameParameter("email")
+                .passwordParameter("password")
+                .defaultSuccessUrl("/admin/home")
+            )
+            .logout((logout) -> logout
+                .logoutUrl("/admin/logout")
+                .logoutSuccessUrl("/admin/home")
+                .invalidateHttpSession(true)
+                .clearAuthentication(true)
+            )
             .httpBasic(AbstractHttpConfigurer::disable)
             .sessionManagement(
-                configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
             )
             .authorizeHttpRequests(registry -> registry
                 .requestMatchers(getMatcherForUserAndAdmin())
@@ -111,5 +127,17 @@ public class SecurityConfig {
             antMatcher(HttpMethod.GET, "/api/v1/users/notifications"),
             antMatcher(HttpMethod.GET, "/api/v1/users/notifications/exist")
         );
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(
+        AuthenticationConfiguration authenticationConfiguration
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
+++ b/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
@@ -130,7 +130,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    AuthenticationManager authenticationManager(
+    public AuthenticationManager authenticationManager(
         AuthenticationConfiguration authenticationConfiguration
     ) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();

--- a/app/api/common-api/src/main/java/org/example/security/service/AdminSecurityService.java
+++ b/app/api/common-api/src/main/java/org/example/security/service/AdminSecurityService.java
@@ -1,0 +1,31 @@
+package org.example.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.entity.Admin;
+import org.example.usecase.AdminUseCase;
+import org.example.vo.UserRoleApiType;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSecurityService implements UserDetailsService {
+
+    private final AdminUseCase adminUseCase;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Admin admin = adminUseCase.findByEmail(email);
+
+        return new User(
+            admin.getEmail(),
+            passwordEncoder.encode(admin.getPassword()),
+            UserRoleApiType.ADMIN.getAdminAuthority()
+        );
+    }
+}

--- a/app/api/user-api/src/main/java/org/example/controller/AdminController.java
+++ b/app/api/user-api/src/main/java/org/example/controller/AdminController.java
@@ -26,6 +26,12 @@ public class AdminController {
         return "home";
     }
 
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/login")
+    public String login() {
+        return "login_form";
+    }
+
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/signup")
     public void signup(

--- a/app/api/user-api/src/main/resources/templates/artist_list_form.html
+++ b/app/api/user-api/src/main/resources/templates/artist_list_form.html
@@ -1,5 +1,6 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
-<div layout:fragment="content" class="container my-3">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<div sec:authorize="isAuthenticated()" layout:fragment="content" class="container my-3">
   <div class="container my-3">
     <h2 class="text-center">아티스트 목록</h2>
     <table class="table table-striped">

--- a/app/api/user-api/src/main/resources/templates/genre_create_form.html
+++ b/app/api/user-api/src/main/resources/templates/genre_create_form.html
@@ -1,5 +1,6 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
-<div layout:fragment="content" class="container my-3">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<div sec:authorize="isAuthenticated()" layout:fragment="content" class="container my-3">
   <div class="container my-3">
     <div class="row justify-content-center">
       <div class="col-md-6">

--- a/app/api/user-api/src/main/resources/templates/genre_form.html
+++ b/app/api/user-api/src/main/resources/templates/genre_form.html
@@ -1,5 +1,6 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
-<div layout:fragment="content" class="container">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<div sec:authorize="isAuthenticated()" layout:fragment="content" class="container">
   <div class="my-3">
     <h2 class="text-center">장르 수정</h2>
     <form th:action="@{/admin/genres/{id}(id=${genre.id})}" method="post">

--- a/app/api/user-api/src/main/resources/templates/genre_list_form.html
+++ b/app/api/user-api/src/main/resources/templates/genre_list_form.html
@@ -1,5 +1,6 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
-<div layout:fragment="content" class="container my-3">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<div sec:authorize="isAuthenticated()" layout:fragment="content" class="container my-3">
   <div class="container my-3">
     <h2 class="text-center">장르 목록</h2>
     <table class="table table-striped">

--- a/app/api/user-api/src/main/resources/templates/home.html
+++ b/app/api/user-api/src/main/resources/templates/home.html
@@ -1,4 +1,5 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
 <div layout:fragment="content" class="container my-3">
   <div class="row">
     <div class="col-md-6">
@@ -6,7 +7,7 @@
         <div class="card-body">
           <h5 class="card-title">공연 추가</h5>
           <p class="card-text">새로운 공연을 추가합니다.</p>
-          <a href="/admin/shows" class="btn btn-primary">추가하기</a>
+          <a sec:authorize="isAuthenticated()" href="/admin/shows" class="btn btn-primary">추가하기</a>
         </div>
       </div>
     </div>
@@ -15,7 +16,7 @@
         <div class="card-body">
           <h5 class="card-title">공연 조회</h5>
           <p class="card-text">등록된 공연을 조회합니다.</p>
-          <a href="/admin/shows/list" class="btn btn-primary">조회하기</a>
+          <a sec:authorize="isAuthenticated()" href="/admin/shows/list" class="btn btn-primary">조회하기</a>
         </div>
       </div>
     </div>
@@ -26,7 +27,7 @@
         <div class="card-body">
           <h5 class="card-title">아티스트 조회</h5>
           <p class="card-text">등록된 아티스트를 조회합니다.</p>
-          <a href="/admin/artists/list" class="btn btn-primary">조회하기</a>
+          <a sec:authorize="isAuthenticated()" href="/admin/artists/list" class="btn btn-primary">조회하기</a>
         </div>
       </div>
     </div>
@@ -37,7 +38,7 @@
         <div class="card-body">
           <h5 class="card-title">장르 추가</h5>
           <p class="card-text">새로운 장르를 추가합니다.</p>
-          <a href="/admin/genres" class="btn btn-primary">추가하기</a>
+          <a sec:authorize="isAuthenticated()" href="/admin/genres" class="btn btn-primary">추가하기</a>
         </div>
       </div>
     </div>
@@ -46,7 +47,7 @@
         <div class="card-body">
           <h5 class="card-title">장르 조회</h5>
           <p class="card-text">등록된 장르를 조회합니다.</p>
-          <a href="/admin/genres/list" class="btn btn-primary">조회하기</a>
+          <a sec:authorize="isAuthenticated()" href="/admin/genres/list" class="btn btn-primary">조회하기</a>
         </div>
       </div>
     </div>

--- a/app/api/user-api/src/main/resources/templates/login_form.html
+++ b/app/api/user-api/src/main/resources/templates/login_form.html
@@ -1,0 +1,20 @@
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<div layout:fragment="content" class="container my-3">
+  <form th:action="@{/admin/login}" method="post">
+    <div th:if="${param.error}">
+      <div class="alert alert-danger">
+        사용자ID 또는 비밀번호를 확인해 주세요.
+      </div>
+    </div>
+    <div class="mb-3">
+      <label for="email" class="form-label">관리자 이메일</label>
+      <input type="email" name="email" id="email" class="form-control">
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">비밀번호</label>
+      <input type="password" name="password" id="password" class="form-control">
+    </div>
+    <button type="submit" class="btn btn-primary">로그인</button>
+  </form>
+</div>
+</html>

--- a/app/api/user-api/src/main/resources/templates/navbar.html
+++ b/app/api/user-api/src/main/resources/templates/navbar.html
@@ -1,4 +1,5 @@
-<nav th:fragment="navbarFragment" class="navbar navbar-expand-lg navbar-light bg-light border-bottom">
+<html lang="ko" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+  <nav th:fragment="navbarFragment" class="navbar navbar-expand-lg navbar-light bg-light border-bottom">
   <div class="container-fluid">
     <a class="navbar-brand" href="/admin/home">Show Pot Admin</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
@@ -8,9 +9,11 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
-
+          <a class="nav-link" sec:authorize="isAnonymous()" th:href="@{/admin/login}">로그인</a>
+          <a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/admin/logout}">로그아웃</a>
         </li>
       </ul>
     </div>
   </div>
-</nav>
+  </nav>
+</html>

--- a/app/api/user-api/src/main/resources/templates/show_create_form.html
+++ b/app/api/user-api/src/main/resources/templates/show_create_form.html
@@ -1,5 +1,6 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
-<div layout:fragment="content" class="container my-3" style="background-color: #ffffff; padding: 30px; box-shadow: 0 0 10px rgba(0,0,0,0.1); border-radius: 8px; width: 100%; max-width: 500px;">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<div sec:authorize="isAuthenticated()"  layout:fragment="content" class="container my-3" style="background-color: #ffffff; padding: 30px; box-shadow: 0 0 10px rgba(0,0,0,0.1); border-radius: 8px; width: 100%; max-width: 500px;">
 
   <form action="/admin/shows" method="post" enctype="multipart/form-data" style="padding: 20px;">
     <h2 class="text-center">추가할 공연 정보</h2>

--- a/app/api/user-api/src/main/resources/templates/show_form.html
+++ b/app/api/user-api/src/main/resources/templates/show_form.html
@@ -1,5 +1,6 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
-<div layout:fragment="content" class="container my-3" style="background-color: #ffffff; padding: 30px; box-shadow: 0 0 10px rgba(0,0,0,0.1); border-radius: 8px; width: 100%; max-width: 500px;">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<div sec:authorize="isAuthenticated()" layout:fragment="content" class="container my-3" style="background-color: #ffffff; padding: 30px; box-shadow: 0 0 10px rgba(0,0,0,0.1); border-radius: 8px; width: 100%; max-width: 500px;">
   <form th:action="@{/admin/shows/{id}(id=${shows.id})}" method="post" enctype="multipart/form-data" style="padding: 20px;">
     <h2 class="text-center">공연 수정</h2>
     <input type="hidden" name="_method" value="put" />

--- a/app/api/user-api/src/main/resources/templates/show_list_form.html
+++ b/app/api/user-api/src/main/resources/templates/show_list_form.html
@@ -1,6 +1,7 @@
-<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<html lang="ko" layout:decorate="~{layout}" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
 <body>
-<div layout:fragment="content" class="container-fluid my-3">
+<div sec:authorize="isAuthenticated()" layout:fragment="content" class="container-fluid my-3">
   <div class="container-fluid my-3">
     <h2 class="text-center">공연 목록</h2>
     <table class="table table-striped" width="100%">

--- a/app/domain/user-domain/src/main/java/org/example/repository/admin/AdminRepository.java
+++ b/app/domain/user-domain/src/main/java/org/example/repository/admin/AdminRepository.java
@@ -1,10 +1,11 @@
 package org.example.repository.admin;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.example.entity.Admin;
 import org.example.repository.user.UserQuerydslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminRepository extends JpaRepository<Admin, UUID>, UserQuerydslRepository {
-
+    Optional<Admin> findByEmail(String email);
 }

--- a/app/domain/user-domain/src/main/java/org/example/usecase/AdminUseCase.java
+++ b/app/domain/user-domain/src/main/java/org/example/usecase/AdminUseCase.java
@@ -1,5 +1,6 @@
 package org.example.usecase;
 
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.example.entity.Admin;
 import org.example.error.AdminError;
@@ -22,5 +23,9 @@ public class AdminUseCase {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(AdminError.EMAIL_DUPLICATED_ERROR);
         }
+    }
+
+    public Admin findByEmail(String email) {
+        return adminRepository.findByEmail(email).orElseThrow(NoSuchElementException::new);
     }
 }


### PR DESCRIPTION
## 😋 작업한 내용

- 어드민 페이지에 어드민에 대한 인증/인가가 존재하지 않습니다.
- 어드민 페이지가 웹뷰로 제작이 되었기에, 일단 세션 방식의 로그인을 구현하여 보안을 한층 쌓았습니다.
- 어드민 데이터는 따로 회원가입 없이, 데이터베이스에 삽입해야 합니다.
- 공연 조회, 생성 등 어드민 기능에 해당하는 페이지도 로그인을 한 후 업무를 수행할 수 있습니다.

## 🙏 PR Point
로그인 전
<img width="1570" alt="image" src="https://github.com/user-attachments/assets/d454006c-22ee-49f1-b565-e629c60b8b0e">

로그인 후
<img width="1628" alt="image" src="https://github.com/user-attachments/assets/725df921-2fc3-40d9-9319-2e189ab86e04">

## 👍 관련 이슈

- Resolved : #15 


---