### PR TITLE
fix : 구독하지 않은 아티스트 응답 타입 수정 & Spotify API 필터링 추가

### DIFF
--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSearchPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSearchPaginationApiParam.java
@@ -17,7 +17,7 @@ public record ArtistSearchPaginationApiParam(
     String name,
 
     @Schema(description = "아티스트의 스포티파이 ID")
-    String artistSpotifyId,
+    String spotifyId,
 
     @Schema(description = "아티스트 구독 여부")
     boolean isSubscribed
@@ -28,7 +28,7 @@ public record ArtistSearchPaginationApiParam(
             .id(param.artistId())
             .name(param.name())
             .imageURL(param.artistImageUrl())
-            .artistSpotifyId(param.artistSpotifyId())
+            .spotifyId(param.artistSpotifyId())
             .isSubscribed(param.isSubscribed())
             .build();
     }

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistUnsubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistUnsubscriptionPaginationApiParam.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 public record ArtistUnsubscriptionPaginationApiParam(
     @Schema(description = "아티스트 ID")
     UUID id,
+    @Schema(description = "아티스트의 스포티파이 ID")
+    String artistSpotifyId,
     @Schema(description = "아티스트 이미지 URL")
     String imageURL,
     @Schema(description = "아티스트 이름")
@@ -18,6 +20,7 @@ public record ArtistUnsubscriptionPaginationApiParam(
     ) {
         return new ArtistUnsubscriptionPaginationApiParam(
             param.id(),
+            param.spotifyId(),
             param.image(),
             param.name()
         );

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistUnsubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistUnsubscriptionPaginationApiParam.java
@@ -8,7 +8,7 @@ public record ArtistUnsubscriptionPaginationApiParam(
     @Schema(description = "아티스트 ID")
     UUID id,
     @Schema(description = "아티스트의 스포티파이 ID")
-    String artistSpotifyId,
+    String spotifyId,
     @Schema(description = "아티스트 이미지 URL")
     String imageURL,
     @Schema(description = "아티스트 이름")

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/response/ArtistIdsApiResponse.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/response/ArtistIdsApiResponse.java
@@ -9,7 +9,7 @@ public record ArtistIdsApiResponse(
     UUID id,
 
     @Schema(description = "아티스트의 스포티파이 ID")
-    String artistSpotifyId
+    String spotifyId
 ) {
 
     public static ArtistIdsApiResponse from(ArtistIdsServiceResponse response) {

--- a/app/api/show-api/src/main/java/com/example/artist/service/dto/param/ArtistUnsubscriptionPaginationServiceParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/dto/param/ArtistUnsubscriptionPaginationServiceParam.java
@@ -5,6 +5,7 @@ import org.example.dto.artist.response.ArtistSimpleDomainResponse;
 
 public record ArtistUnsubscriptionPaginationServiceParam(
     UUID id,
+    String spotifyId,
     String image,
     String name
 ) {
@@ -12,6 +13,7 @@ public record ArtistUnsubscriptionPaginationServiceParam(
     public ArtistUnsubscriptionPaginationServiceParam(ArtistSimpleDomainResponse response) {
         this(
             response.id(),
+            response.spotifyId(),
             response.image(),
             response.name()
         );

--- a/app/domain/show-domain/src/main/java/org/example/dto/artist/response/ArtistSimpleDomainResponse.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/artist/response/ArtistSimpleDomainResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 @Builder
 public record ArtistSimpleDomainResponse(
     UUID id,
+    String spotifyId,
     String name,
     String image
 ) {

--- a/app/domain/show-domain/src/main/java/org/example/repository/artist/ArtistQuerydslRepositoryImpl.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/artist/ArtistQuerydslRepositoryImpl.java
@@ -84,6 +84,7 @@ public class ArtistQuerydslRepositoryImpl implements ArtistQuerydslRepository {
                 Projections.constructor(
                     ArtistSimpleDomainResponse.class,
                     artist.id,
+                    artist.spotifyId,
                     artist.name,
                     artist.image
                 )

--- a/app/domain/show-domain/src/main/java/org/example/usecase/ArtistUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/ArtistUseCase.java
@@ -175,7 +175,7 @@ public class ArtistUseCase {
         ArtistSearchPortResponse response
     ) {
         return response.artists().stream()
-            .filter(artist -> artist.genres().stream()
+            .filter(artist -> !artist.genres().isEmpty() && artist.genres().stream()
                 .noneMatch(ArtistFilterType::isKoreanArtist))
             .toList();
     }


### PR DESCRIPTION
## 😋 작업한 내용

- 구독하지 않은 아티스트 목록 조회 API에서 SpotifyId 응답이 누락되어 추가했습니다.
- Spotify API 요청 시 장르가 없으면 필터링되게 했습니다.
   - "김연아" 같이 아티스트는 아니지만 앨범이 있는 경우 spotify API에서는 장르가 비어있는데, showpot에서는 검색이 되면 안됨으로!  

## 🙏 PR Point

- 간단한 응답 변수명 수정이라 클라이언트의 빠른 대응을 위해 머지하겠습니다!

## 👍 관련 이슈

- Resolved : #33 


---