### PR TITLE
feat: ticketing-alert pub 전송 시 userId 활용

### DIFF
--- a/app/api/show-api/src/main/java/com/example/pub/message/TicketingAlertsToReserveServiceMessage.java
+++ b/app/api/show-api/src/main/java/com/example/pub/message/TicketingAlertsToReserveServiceMessage.java
@@ -8,7 +8,7 @@ import org.example.dto.usershow.response.TicketingAlertsDomainResponse;
 
 @Builder
 public record TicketingAlertsToReserveServiceMessage(
-    String userFcmToken,
+    UUID userId,
     String name,
     UUID showId,
     LocalDateTime ticketingAt,
@@ -18,10 +18,10 @@ public record TicketingAlertsToReserveServiceMessage(
 
     public static TicketingAlertsToReserveServiceMessage of(
         TicketingAlertsDomainResponse response,
-        String userFcmToken
+        UUID userId
     ) {
         return TicketingAlertsToReserveServiceMessage.builder()
-            .userFcmToken(userFcmToken)
+            .userId(userId)
             .name(response.name())
             .showId(response.showId())
             .ticketingAt(response.ticketingAt())

--- a/app/api/show-api/src/main/java/com/example/show/service/UserShowService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/UserShowService.java
@@ -91,7 +91,6 @@ public class UserShowService {
             throw new BusinessException(ShowError.TICKETING_ALERT_RESERVED_ERROR);
         }
 
-        String userFcmToken = userUseCase.findUserFcmTokensByUserId(request.userId());
         var domainResponse = ticketingAlertUseCase.alertReservation(
             request.toDomainRequest(
                 showTicketingTime.getShow().getTitle(),
@@ -101,7 +100,7 @@ public class UserShowService {
 
         messagePublisher.publishTicketingReservation(
             "ticketingAlert",
-            TicketingAlertsToReserveServiceMessage.of(domainResponse, userFcmToken)
+            TicketingAlertsToReserveServiceMessage.of(domainResponse, request.userId())
         );
     }
 

--- a/app/domain/common-domain/src/main/resources/schema.sql
+++ b/app/domain/common-domain/src/main/resources/schema.sql
@@ -258,7 +258,7 @@ create table alarm.ticketing_alert
     show_id             uuid         not null,
     ticketing_time      timestamp(3) not null,
     name                varchar(255) not null,
-    user_fcm_token      varchar(255) not null,
+    user_id             uuid         not null,
     primary key (id)
 );
 

--- a/app/infrastructure/message-queue/src/main/java/org/example/message/TicketingReservationInfraMessage.java
+++ b/app/infrastructure/message-queue/src/main/java/org/example/message/TicketingReservationInfraMessage.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 
 @Builder
 public record TicketingReservationInfraMessage(
-    String userFcmToken,
+    UUID userId,
     String name,
     UUID showId,
     String ticketingAt,
@@ -20,7 +20,7 @@ public record TicketingReservationInfraMessage(
         TicketingAlertsToReserveServiceMessage message
     ) {
         return TicketingReservationInfraMessage.builder()
-            .userFcmToken(message.userFcmToken())
+            .userId(message.userId())
             .name(message.name())
             .showId(message.showId())
             .ticketingAt(message.ticketingAt().toString())


### PR DESCRIPTION
## 😋 작업한 내용

- alarm.ticketing_alert 의 user_fcm_token -> user_id 로 스키마 수정
- pub 시 userFcmToken 을 찾아와 넣지 않고 userId를 넣어 전송

## 🙏 PR Point

- 

## 👍 관련 이슈

- Resolved : #51 


---