### PR TITLE
feat: comment 및 report jpa entity 추가

### DIFF
--- a/app/domain/common-domain/src/main/resources/schema.sql
+++ b/app/domain/common-domain/src/main/resources/schema.sql
@@ -21,6 +21,8 @@ drop table if exists show_ticketing_time cascade;
 drop table if exists social_login cascade;
 drop table if exists ticketing_alert cascade;
 drop table if exists users cascade;
+drop table if exists comment cascade;
+drop table if exists report cascade;
 
 create table admin
 (
@@ -192,15 +194,40 @@ create table ticketing_alert
 
 create table users
 (
-    id         uuid          not null,
-    created_at timestamp(3)  not null,
-    updated_at timestamp(3)  not null,
-    is_deleted boolean       not null,
-    birth      date          not null,
-    fcm_token  varchar(1000) not null,
-    gender     varchar(255)  not null check (gender in ('MAN', 'WOMAN', 'NOT_CHOSEN')),
-    nickname   varchar(255)  not null unique,
-    role       varchar(255)  not null check (role in ('GUEST', 'USER', 'ADMIN')),
+    id             uuid          not null,
+    created_at     timestamp(3)  not null,
+    updated_at     timestamp(3)  not null,
+    is_deleted     boolean       not null,
+    birth          date          not null,
+    fcm_token      varchar(1000) not null,
+    gender         varchar(255)  not null check (gender in ('MAN', 'WOMAN', 'NOT_CHOSEN')),
+    nickname       varchar(255)  not null unique,
+    role           varchar(255)  not null check (role in ('GUEST', 'USER', 'ADMIN')),
+    profile_number integer,
+    primary key (id)
+);
+
+create table comment (
+    id           UUID         not null,
+    is_deleted   boolean      not null,
+    created_at   timestamp(3) not null,
+    updated_at   timestamp(3) not null,
+    parent_id    uuid,
+    ref_id       uuid         not null,
+    user_id      uuid         not null,
+    comment_type varchar(255) not null check (comment_type in ('SHOW')),
+    content      varchar(255) not null,
+    primary key (id)
+);
+
+create table report (
+    id          uuid         not null,
+    is_deleted  boolean      not null,
+    created_at  timestamp(3) not null,
+    updated_at  timestamp(3) not null,
+    comment_id  uuid         not null,
+    user_id     uuid         not null,
+    report_type varchar(255) not null check (report_type in ('GRAFFITI','PORNOGRAPHY','COMMERCIAL_AD','IMPERSONATION','PROFANITY','ETC','BLOCKING')),
     primary key (id)
 );
 

--- a/app/domain/common-domain/src/main/resources/schema.sql
+++ b/app/domain/common-domain/src/main/resources/schema.sql
@@ -203,7 +203,7 @@ create table users
     gender         varchar(255)  not null check (gender in ('MAN', 'WOMAN', 'NOT_CHOSEN')),
     nickname       varchar(255)  not null unique,
     role           varchar(255)  not null check (role in ('GUEST', 'USER', 'ADMIN')),
-    profile_number integer,
+    profile_url    varchar(255),
     primary key (id)
 );
 

--- a/app/domain/show-domain/src/main/java/org/example/entity/comment/Comment.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/comment/Comment.java
@@ -1,0 +1,51 @@
+package org.example.entity.comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comment")
+public class Comment extends BaseEntity {
+
+    @Column(name = "ref_id", nullable = false)
+    private UUID refId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "parent_id")
+    private UUID parentId;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "comment_type", nullable = false)
+    private CommentType commentType;
+
+    @Builder
+    private Comment(
+        UUID refId,
+        UUID userId,
+        UUID parentId,
+        String content,
+        CommentType commentType
+    ) {
+        this.refId = refId;
+        this.userId = userId;
+        this.parentId = parentId;
+        this.content = content;
+        this.commentType = commentType;
+    }
+}

--- a/app/domain/show-domain/src/main/java/org/example/entity/comment/CommentType.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/comment/CommentType.java
@@ -1,0 +1,5 @@
+package org.example.entity.comment;
+
+public enum CommentType {
+    SHOW,
+}

--- a/app/domain/show-domain/src/main/java/org/example/entity/comment/Report.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/comment/Report.java
@@ -1,0 +1,41 @@
+package org.example.entity.comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "report")
+public class Report extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "comment_id", nullable = false)
+    private UUID commentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_type", nullable = false)
+    private ReportType reportType;
+
+    @Builder
+    private Report(
+        UUID userId,
+        UUID commentId,
+        ReportType reportType
+    ) {
+        this.userId = userId;
+        this.commentId = commentId;
+        this.reportType = reportType;
+    }
+}

--- a/app/domain/show-domain/src/main/java/org/example/entity/comment/ReportType.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/comment/ReportType.java
@@ -1,5 +1,14 @@
 package org.example.entity.comment;
 
+/**
+ * GRAFFITI: 도배
+ * PORNOGRAPHY: 음란물
+ * COMMERCIAL_AD: 상업적 광고
+ * IMPERSONATION: 사칭
+ * PROFANITY: 욕설
+ * ETC: 기타
+ * BLOCKING: 차단
+ */
 public enum ReportType {
     GRAFFITI, PORNOGRAPHY, COMMERCIAL_AD, IMPERSONATION, PROFANITY, ETC, BLOCKING;
 }

--- a/app/domain/show-domain/src/main/java/org/example/entity/comment/ReportType.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/comment/ReportType.java
@@ -1,0 +1,5 @@
+package org.example.entity.comment;
+
+public enum ReportType {
+    GRAFFITI, PORNOGRAPHY, COMMERCIAL_AD, IMPERSONATION, PROFANITY, ETC, BLOCKING;
+}

--- a/app/domain/user-domain/src/main/java/org/example/entity/User.java
+++ b/app/domain/user-domain/src/main/java/org/example/entity/User.java
@@ -37,8 +37,8 @@ public class User extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private UserRole userRole;
 
-    @Column(name = "profile_number")
-    private Integer profileNumber;
+    @Column(name = "profile_url")
+    private String profileUrl;
 
     @Builder
     public User(

--- a/app/domain/user-domain/src/main/java/org/example/entity/User.java
+++ b/app/domain/user-domain/src/main/java/org/example/entity/User.java
@@ -37,6 +37,9 @@ public class User extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private UserRole userRole;
 
+    @Column(name = "profile_number")
+    private Integer profileNumber;
+
     @Builder
     public User(
         String nickname,


### PR DESCRIPTION
## 😋 작업한 내용

- Comment, Report 엔티티 추가
- User 엔티티에 profileNumber 필드 추가 (이미 추가된 User DB Row를 고려하여 nullable = true 로 놔둠)
- schema.sql 은 아직 수정하지 않음. JPA 엔티티 수정사항 없으면 추가하는게 좋을 것 같아서 그대로 둠.

## 🙏 PR Point

- JPA 엔티티의 기존 컨벤션과 일치하는지 확인해주시면 감사하겠습니다.
- show 댓글이나 이후 다른 종류 댓글이 추가되어도 관련된 도메인이라 판단해서 Show 도메인 밑에 두었는데, 괜찮은지 피드백해주시면 좋을 것 같습니다.

## 👍 관련 이슈

- Resolved : #53


---