### PR TITLE
feat: 공연 댓글 목록 조회 API 생성

### DIFF
--- a/.github/workflows/showpot-dev-cd.yml
+++ b/.github/workflows/showpot-dev-cd.yml
@@ -87,7 +87,7 @@ jobs:
           script: |
             cd /home/ec2-user/deployment/
             docker-compose -f docker-compose-dev.yml down
-            docker system prune -f --volumes
+            docker system prune -a -f
             docker-compose -f docker-compose-dev.yml up -d --build
 
       - name: Remove Github Actions IP from Security Group

--- a/.github/workflows/showpot-prod-cd.yml
+++ b/.github/workflows/showpot-prod-cd.yml
@@ -99,8 +99,7 @@ jobs:
             docker ps -q --filter "name=core" | xargs -r docker stop
             docker ps -aq --filter "name=core" | xargs -r docker rm
             aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ steps.login-ecr.outputs.registry }}
-            docker image prune -f -a
-            docker volume prune -f -a
+            docker system prune -a -f
             docker pull ${{ env.IMAGE_URI }}
             docker run -d --name core -p 8080:8080 -e ENVIRONMENT=prod --network prod-network ${{ env.IMAGE_URI }}
 

--- a/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
+++ b/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
@@ -143,7 +143,10 @@ public class SecurityConfig {
             antMatcher(HttpMethod.POST, "/api/v1/artists/unsubscribe"),
             antMatcher(HttpMethod.GET, "/api/v1/artists/subscriptions"),
             antMatcher(HttpMethod.GET, "/api/v1/users/notifications"),
-            antMatcher(HttpMethod.GET, "/api/v1/users/notifications/exist")
+            antMatcher(HttpMethod.GET, "/api/v1/users/notifications/exist"),
+            antMatcher(HttpMethod.POST, "/api/v1/comments"),
+            antMatcher(HttpMethod.DELETE, "/api/v1/comments/{commentId}"),
+            antMatcher(HttpMethod.POST, "/api/v1/comments/{commentId}/report")
         );
     }
 

--- a/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
+++ b/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
@@ -146,7 +146,8 @@ public class SecurityConfig {
             antMatcher(HttpMethod.GET, "/api/v1/users/notifications/exist"),
             antMatcher(HttpMethod.POST, "/api/v1/comments"),
             antMatcher(HttpMethod.DELETE, "/api/v1/comments/{commentId}"),
-            antMatcher(HttpMethod.POST, "/api/v1/comments/{commentId}/report")
+            antMatcher(HttpMethod.POST, "/api/v1/comments/{commentId}/report"),
+            antMatcher(HttpMethod.GET, "/api/v1/comments/{refId}/**")
         );
     }
 

--- a/app/api/common-api/src/main/java/org/example/dto/response/CursorApiResponse.java
+++ b/app/api/common-api/src/main/java/org/example/dto/response/CursorApiResponse.java
@@ -27,4 +27,8 @@ public record CursorApiResponse(
     public static <T> T getLastElement(List<T> list) {
         return list.isEmpty() ? null : list.get(list.size() - 1);
     }
+
+    public static <T> T getFirstElement(List<T> list) {
+        return list.isEmpty() ? null : list.get(0);
+    }
 }

--- a/app/api/common-api/src/main/java/org/example/error/GlobalExceptionHandler.java
+++ b/app/api/common-api/src/main/java/org/example/error/GlobalExceptionHandler.java
@@ -52,7 +52,7 @@ public class GlobalExceptionHandler {
         String errorId = UUID.randomUUID().toString();
         ErrorResponse response = ErrorResponse.messageCustomErrorResponseBuilder()
             .errorId(errorId)
-            .message(e.getMessage())
+            .message(GlobalError.ELEMENT_NOT_FOUND.getClientMessage())
             .error(GlobalError.ELEMENT_NOT_FOUND)
             .build();
 

--- a/app/api/show-api/src/main/java/com/example/comment/controller/CommentController.java
+++ b/app/api/show-api/src/main/java/com/example/comment/controller/CommentController.java
@@ -1,19 +1,26 @@
 package com.example.comment.controller;
 
-import com.example.comment.controller.dto.CommentReportApiRequest;
-import com.example.comment.controller.dto.CommentWriteApiRequest;
+import com.example.comment.controller.dto.param.CommentApiParam;
+import com.example.comment.controller.dto.request.CommentPaginationApiRequest;
+import com.example.comment.controller.dto.request.CommentReportApiRequest;
+import com.example.comment.controller.dto.request.CommentWriteApiRequest;
 import com.example.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.example.dto.response.CursorApiResponse;
+import org.example.dto.response.PaginationApiResponse;
 import org.example.dto.response.SuccessResponse;
 import org.example.dto.response.SuccessResponse.Empty;
 import org.example.security.dto.AuthenticatedInfo;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -65,4 +72,35 @@ public class CommentController {
 
         return SuccessResponse.emptyData();
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{refId}")
+    @Operation(summary = "댓글 목록 조회")
+    public SuccessResponse<PaginationApiResponse<CommentApiParam>> readComments(
+        @AuthenticationPrincipal AuthenticatedInfo info,
+        @PathVariable UUID refId,
+        @Valid @ParameterObject CommentPaginationApiRequest request
+    ) {
+        var commentPagination = commentService.getComments(request.toServiceRequest(refId, info.userId()));
+
+        CursorApiResponse cursor;
+        if (request.isInverted()) {
+            cursor = Optional.ofNullable(CursorApiResponse.getFirstElement(commentPagination.data()))
+                .map(element -> CursorApiResponse.toCursorResponse(element.commentId(), element.createdAt()))
+                .orElse(CursorApiResponse.noneCursor());
+        } else {
+            cursor = Optional.ofNullable(CursorApiResponse.getLastElement(commentPagination.data()))
+                .map(element -> CursorApiResponse.toCursorResponse(element.commentId(), element.createdAt()))
+                .orElse(CursorApiResponse.noneCursor());
+        }
+
+        return SuccessResponse.ok(
+            PaginationApiResponse.<CommentApiParam>builder()
+                .data(commentPagination.data())
+                .hasNext(commentPagination.hasNext())
+                .cursor(cursor)
+                .build()
+        );
+    }
+
 }

--- a/app/api/show-api/src/main/java/com/example/comment/controller/CommentController.java
+++ b/app/api/show-api/src/main/java/com/example/comment/controller/CommentController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.example.dto.response.SuccessResponse;
 import org.example.dto.response.SuccessResponse.Empty;
 import org.example.security.dto.AuthenticatedInfo;
-import org.example.util.ValidatorUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/comment")
+@RequestMapping("/api/v1/comments")
 @Tag(name = "댓글")
 public class CommentController {
 
@@ -37,8 +36,7 @@ public class CommentController {
         @AuthenticationPrincipal AuthenticatedInfo info,
         @RequestBody @Valid CommentWriteApiRequest request
     ) {
-        UUID userId = ValidatorUser.getUserId(info);
-        commentService.writeComment(request.toServiceRequest(), userId);
+        commentService.writeComment(request.toServiceRequest(), info.userId());
 
         return SuccessResponse.emptyData();
     }
@@ -50,8 +48,7 @@ public class CommentController {
         @AuthenticationPrincipal AuthenticatedInfo info,
         @PathVariable UUID commentId
     ) {
-        UUID userId = ValidatorUser.getUserId(info);
-        commentService.deleteComment(commentId, userId);
+        commentService.deleteComment(commentId, info.userId());
 
         return SuccessResponse.emptyData();
     }
@@ -64,8 +61,7 @@ public class CommentController {
         @PathVariable UUID commentId,
         @RequestBody @Valid CommentReportApiRequest request
     ) {
-        UUID userId = ValidatorUser.getUserId(info);
-        commentService.reportComment(request.toServiceRequest(), commentId, userId);
+        commentService.reportComment(request.toServiceRequest(), commentId, info.userId());
 
         return SuccessResponse.emptyData();
     }

--- a/app/api/show-api/src/main/java/com/example/comment/controller/dto/CommentReportApiRequest.java
+++ b/app/api/show-api/src/main/java/com/example/comment/controller/dto/CommentReportApiRequest.java
@@ -1,7 +1,10 @@
 package com.example.comment.controller.dto;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.example.dto.comment.request.CommentReportDomainRequest;
 import org.example.vo.ReportType;
 
@@ -10,9 +13,18 @@ public record CommentReportApiRequest(
             example = "(GRAFFITI, PORNOGRAPHY, COMMERCIAL_AD, IMPERSONATION, PROFANITY, ETC, BLOCKING) 중 하나",
             description = "신고 타입")
     @NotNull(message = "신고 타입을 입력해주세요.")
-    ReportType reportType
+    ReportType reportType,
+
+    @Size(max = 255, message = "직접 입력 내용은 최대 255자까지 입력 가능합니다.")
+    @NotBlank
+    @NotEmpty
+    String directInput
 ) {
     public CommentReportDomainRequest toServiceRequest() {
-        return new CommentReportDomainRequest(reportType);
+        if (directInput != null) {
+            return new CommentReportDomainRequest(reportType, directInput);
+        }
+
+        return new CommentReportDomainRequest(reportType, null);
     }
 }

--- a/app/api/show-api/src/main/java/com/example/comment/controller/dto/param/CommentApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/comment/controller/dto/param/CommentApiParam.java
@@ -1,0 +1,32 @@
+package com.example.comment.controller.dto.param;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CommentApiParam(
+
+    @Schema(description = "댓글 ID")
+    UUID commentId,
+
+    @Schema(description = "부모 댓글 ID")
+    UUID parentId,
+
+    @Schema(description = "댓글 내용")
+    String content,
+
+    @Schema(description = "차단 여부")
+    boolean isBlocked,
+
+    @Schema(description = "사용자 프로필 URL")
+    String profileURL,
+
+    @Schema(description = "사용자 이름")
+    String userName,
+
+    @Schema(description = "댓글 생성 시간")
+    String createdAt
+) {
+
+}

--- a/app/api/show-api/src/main/java/com/example/comment/controller/dto/request/CommentPaginationApiRequest.java
+++ b/app/api/show-api/src/main/java/com/example/comment/controller/dto/request/CommentPaginationApiRequest.java
@@ -1,0 +1,44 @@
+package com.example.comment.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Max;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.example.dto.comment.request.CommentPaginationDomainRequest;
+import org.example.vo.CommentType;
+
+public record CommentPaginationApiRequest(
+    @Parameter(description = "댓글 타입", required = true)
+    CommentType type,
+
+    @Parameter(description = "스크롤 방향", required = true)
+    boolean isInverted,
+
+    @Parameter(description = "이전 페이지네이션의 cursorId / 최초 조회라면 null")
+    UUID cursorId,
+
+    @Parameter(description = "이전 페이지네이션의 cursorValue/ 최초 조회라면 null")
+    LocalDateTime cursorValue,
+
+    @Parameter(example = "30")
+    @Max(value = 30, message = "조회하는 데이터의 최대 개수는 30입니다.")
+    Integer size
+) {
+    public CommentPaginationApiRequest {
+        if (size == null) {
+            size = 30;
+        }
+    }
+
+    public CommentPaginationDomainRequest toServiceRequest(UUID refId, UUID userId) {
+        return CommentPaginationDomainRequest.builder()
+            .type(type)
+            .refId(refId)
+            .userId(userId)
+            .isInverted(isInverted)
+            .cursorId(cursorId)
+            .cursorValue(cursorValue)
+            .size(size)
+            .build();
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/comment/controller/dto/request/CommentReportApiRequest.java
+++ b/app/api/show-api/src/main/java/com/example/comment/controller/dto/request/CommentReportApiRequest.java
@@ -1,4 +1,4 @@
-package com.example.comment.controller.dto;
+package com.example.comment.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;

--- a/app/api/show-api/src/main/java/com/example/comment/controller/dto/request/CommentWriteApiRequest.java
+++ b/app/api/show-api/src/main/java/com/example/comment/controller/dto/request/CommentWriteApiRequest.java
@@ -1,4 +1,4 @@
-package com.example.comment.controller.dto;
+package com.example.comment.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.NotBlank;

--- a/app/api/show-api/src/main/java/com/example/comment/error/CommentError.java
+++ b/app/api/show-api/src/main/java/com/example/comment/error/CommentError.java
@@ -29,7 +29,7 @@ public enum CommentError implements BusinessError {
     COMMENT_AUTHOR_DIFFERENT_ERROR {
         @Override
         public int getHttpStatus() {
-            return 400;
+            return 403;
         }
 
         @Override

--- a/app/api/show-api/src/main/java/com/example/comment/error/CommentError.java
+++ b/app/api/show-api/src/main/java/com/example/comment/error/CommentError.java
@@ -1,0 +1,50 @@
+package com.example.comment.error;
+
+import org.example.exception.BusinessError;
+
+public enum CommentError implements BusinessError {
+
+    COMMENT_AUTHOR_REPORT_ERROR {
+        @Override
+        public int getHttpStatus() {
+            return 400;
+        }
+
+        @Override
+        public String getErrorCode() {
+            return "CMT-001";
+        }
+
+        @Override
+        public String getClientMessage() {
+            return "댓글 저자는 자신의 댓글을 신고/차단할 수 없습니다.";
+        }
+
+        @Override
+        public String getLogMessage() {
+            return "댓글 저자가 본인의 댓글을 신고/차단 요청함";
+        }
+    },
+
+    COMMENT_AUTHOR_DIFFERENT_ERROR {
+        @Override
+        public int getHttpStatus() {
+            return 400;
+        }
+
+        @Override
+        public String getErrorCode() {
+            return "CMT-002";
+        }
+
+        @Override
+        public String getClientMessage() {
+            return "댓글 저자가 아닙니다.";
+        }
+
+        @Override
+        public String getLogMessage() {
+            return "댓글 저자가 아닌 신원이 요청함";
+        }
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/comment/service/CommentService.java
+++ b/app/api/show-api/src/main/java/com/example/comment/service/CommentService.java
@@ -64,8 +64,8 @@ public class CommentService {
                     .parentId(comment.parentId())
                     .content(comment.content())
                     .isBlocked(comment.isBlocked())
-                    .profileURL(user.getProfileUrl())
-                    .userName(user.getNickname())
+                    .profileURL(user.getProfileUrl() == null ? null : user.getProfileUrl())
+                    .userName(user.getNickname() == null ? null : user.getNickname())
                     .createdAt(DateTimeUtil.formatDateTime(comment.createdAt()))
                     .build();
             })

--- a/app/api/show-api/src/main/java/com/example/comment/service/CommentService.java
+++ b/app/api/show-api/src/main/java/com/example/comment/service/CommentService.java
@@ -1,12 +1,22 @@
 package com.example.comment.service;
 
+import com.example.comment.controller.dto.param.CommentApiParam;
 import com.example.comment.error.CommentError;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.example.dto.comment.request.CommentPaginationDomainRequest;
 import org.example.dto.comment.request.CommentReportDomainRequest;
 import org.example.dto.comment.request.CommentWriteDomainRequest;
+import org.example.dto.comment.response.CommentDomainResponse;
+import org.example.dto.response.PaginationServiceResponse;
+import org.example.entity.User;
 import org.example.exception.BusinessException;
 import org.example.usecase.CommentUseCase;
+import org.example.usecase.UserUseCase;
+import org.example.util.DateTimeUtil;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class CommentService {
 
     private final CommentUseCase commentUseCase;
+    private final UserUseCase userUseCase;
 
     public void writeComment(CommentWriteDomainRequest request, UUID userId) {
         commentUseCase.writeComment(request, userId);
@@ -33,5 +44,33 @@ public class CommentService {
         } catch (IllegalArgumentException e) {
             throw new BusinessException(CommentError.COMMENT_AUTHOR_REPORT_ERROR);
         }
+    }
+
+    public PaginationServiceResponse<CommentApiParam> getComments(
+        CommentPaginationDomainRequest request) {
+        var commentsByPagination = commentUseCase.findCommentsByPagination(request);
+        List<UUID> userIds = commentsByPagination.data().stream()
+            .map(CommentDomainResponse::userId)
+            .toList();
+        List<User> users = userUseCase.findAllByUserIds(userIds);
+        Map<UUID, User> userMap = users.stream()
+            .collect(Collectors.toMap(User::getId, user -> user));
+
+        List<CommentApiParam> commentApiParams = commentsByPagination.data().stream()
+            .map(comment -> {
+                User user = userMap.get(comment.userId());
+                return CommentApiParam.builder()
+                    .commentId(comment.commentId())
+                    .parentId(comment.parentId())
+                    .content(comment.content())
+                    .isBlocked(comment.isBlocked())
+                    .profileURL(user.getProfileUrl())
+                    .userName(user.getNickname())
+                    .createdAt(DateTimeUtil.formatDateTime(comment.createdAt()))
+                    .build();
+            })
+            .toList();
+
+        return PaginationServiceResponse.of(commentApiParams, commentsByPagination.hasNext());
     }
 }

--- a/app/api/show-api/src/main/java/com/example/comment/service/CommentService.java
+++ b/app/api/show-api/src/main/java/com/example/comment/service/CommentService.java
@@ -1,9 +1,11 @@
 package com.example.comment.service;
 
+import com.example.comment.error.CommentError;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.comment.request.CommentReportDomainRequest;
 import org.example.dto.comment.request.CommentWriteDomainRequest;
+import org.example.exception.BusinessException;
 import org.example.usecase.CommentUseCase;
 import org.springframework.stereotype.Service;
 
@@ -18,10 +20,18 @@ public class CommentService {
     }
 
     public void deleteComment(UUID commentId, UUID userId) {
-        commentUseCase.deleteComment(commentId, userId);
+        try {
+            commentUseCase.deleteComment(commentId, userId);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(CommentError.COMMENT_AUTHOR_DIFFERENT_ERROR);
+        }
     }
 
     public void reportComment(CommentReportDomainRequest request, UUID commentId, UUID userId) {
-        commentUseCase.reportComment(request, commentId, userId);
+        try {
+            commentUseCase.reportComment(request, commentId, userId);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(CommentError.COMMENT_AUTHOR_REPORT_ERROR);
+        }
     }
 }

--- a/app/domain/common-domain/src/main/resources/schema.sql
+++ b/app/domain/common-domain/src/main/resources/schema.sql
@@ -228,6 +228,7 @@ create table report (
     comment_id  uuid         not null,
     user_id     uuid         not null,
     report_type varchar(255) not null check (report_type in ('GRAFFITI','PORNOGRAPHY','COMMERCIAL_AD','IMPERSONATION','PROFANITY','ETC','BLOCKING')),
+    direct_input varchar(255),
     primary key (id)
 );
 

--- a/app/domain/show-domain/src/main/java/org/example/dto/comment/request/CommentPaginationDomainRequest.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/comment/request/CommentPaginationDomainRequest.java
@@ -1,0 +1,19 @@
+package org.example.dto.comment.request;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import org.example.vo.CommentType;
+
+@Builder
+public record CommentPaginationDomainRequest(
+    CommentType type,
+    UUID refId,
+    UUID userId,
+    boolean isInverted,
+    UUID cursorId,
+    LocalDateTime cursorValue,
+    Integer size
+) {
+
+}

--- a/app/domain/show-domain/src/main/java/org/example/dto/comment/request/CommentReportDomainRequest.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/comment/request/CommentReportDomainRequest.java
@@ -5,10 +5,20 @@ import org.example.entity.comment.Report;
 import org.example.vo.ReportType;
 
 public record CommentReportDomainRequest(
-    ReportType reportType
+    ReportType reportType,
+    String directInput
 ) {
 
     public Report toReport(UUID userId, UUID commentId) {
+        if (directInput != null) {
+            return Report.builder()
+                .reportType(reportType)
+                .directInput(directInput)
+                .userId(userId)
+                .commentId(commentId)
+                .build();
+        }
+
         return Report.builder()
             .reportType(reportType)
             .userId(userId)

--- a/app/domain/show-domain/src/main/java/org/example/dto/comment/response/CommentDomainResponse.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/comment/response/CommentDomainResponse.java
@@ -1,0 +1,15 @@
+package org.example.dto.comment.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CommentDomainResponse(
+    UUID commentId,
+    UUID userId,
+    UUID parentId,
+    String content,
+    boolean isBlocked,
+    LocalDateTime createdAt
+) {
+
+}

--- a/app/domain/show-domain/src/main/java/org/example/dto/comment/response/CommentPaginationDomainResponse.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/comment/response/CommentPaginationDomainResponse.java
@@ -1,0 +1,12 @@
+package org.example.dto.comment.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CommentPaginationDomainResponse(
+    List<CommentDomainResponse> data,
+    boolean hasNext
+) {
+
+}

--- a/app/domain/show-domain/src/main/java/org/example/entity/comment/Comment.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/comment/Comment.java
@@ -58,7 +58,7 @@ public class Comment extends BaseEntity {
         this.content = "삭제된 댓글입니다.";
     }
 
-    private boolean isWriter(UUID userId) {
+    public boolean isWriter(UUID userId) {
         return this.userId.equals(userId);
     }
 }

--- a/app/domain/show-domain/src/main/java/org/example/entity/comment/Report.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/comment/Report.java
@@ -29,14 +29,19 @@ public class Report extends BaseEntity {
     @Column(name = "report_type", nullable = false)
     private ReportType reportType;
 
+    @Column(name = "direct_input")
+    private String directInput;
+
     @Builder
     private Report(
         UUID userId,
         UUID commentId,
-        ReportType reportType
+        ReportType reportType,
+        String directInput
     ) {
         this.userId = userId;
         this.commentId = commentId;
         this.reportType = reportType;
+        this.directInput = directInput;
     }
 }

--- a/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentQuerydslRepository.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentQuerydslRepository.java
@@ -1,0 +1,9 @@
+package org.example.repository.comment;
+
+import org.example.dto.comment.request.CommentPaginationDomainRequest;
+import org.example.dto.comment.response.CommentPaginationDomainResponse;
+
+public interface CommentQuerydslRepository {
+
+    CommentPaginationDomainResponse findAllWithCursorPagination(CommentPaginationDomainRequest request);
+}

--- a/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentQuerydslRepositoryImpl.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentQuerydslRepositoryImpl.java
@@ -1,0 +1,109 @@
+
+package org.example.repository.comment;
+
+import static org.example.entity.comment.QComment.comment;
+import static org.example.entity.comment.QReport.report;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.example.dto.comment.request.CommentPaginationDomainRequest;
+import org.example.dto.comment.response.CommentDomainResponse;
+import org.example.dto.comment.response.CommentPaginationDomainResponse;
+import org.example.util.SliceUtil;
+import org.example.vo.CommentType;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentQuerydslRepositoryImpl implements CommentQuerydslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public CommentPaginationDomainResponse findAllWithCursorPagination(
+        CommentPaginationDomainRequest request) {
+
+        List<CommentDomainResponse> result = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    CommentDomainResponse.class,
+                    comment.id,
+                    comment.userId,
+                    comment.parentId,
+                    comment.content,
+                    report.userId.when(request.userId()).then(true).otherwise(false),
+                    comment.createdAt
+                )
+            )
+            .from(comment)
+            .leftJoin(report).on(report.commentId.eq(comment.id))
+            .where(getWhereClauseInCursorPagination(request))
+            .orderBy(comment.createdAt.desc(), comment.id.desc())
+            .limit(request.size() + 1)
+            .fetch();
+
+        Slice<CommentDomainResponse> slice = SliceUtil.makeSlice(request.size(), result);
+
+        return CommentPaginationDomainResponse.builder()
+            .data(slice.getContent())
+            .hasNext(slice.hasNext())
+            .build();
+    }
+
+    private Predicate getWhereClauseInCursorPagination(CommentPaginationDomainRequest request) {
+        BooleanExpression wherePredicate = getDefaultPredicateExpression(request.type(),
+            request.refId());
+
+        if (request.cursorId() == null) {
+            return wherePredicate;
+        }
+
+        if (request.isInverted()) {
+            return wherePredicate.and(createInvertedPredicate(request.cursorId()));
+        }
+
+        return wherePredicate.and(createForwardPredicate(request.cursorId()));
+    }
+
+    private BooleanExpression getDefaultPredicateExpression(CommentType commentType, UUID refId) {
+        return comment.commentType.eq(commentType).and(comment.refId.eq(refId));
+    }
+
+    private BooleanExpression createInvertedPredicate(UUID cursorId) {
+        Tuple cursor = getCursor(cursorId);
+
+        LocalDateTime cursorValue = cursor.get(comment.createdAt);
+        UUID cursorIdValue = cursor.get(comment.id);
+
+        return comment.createdAt.gt(cursorValue)
+            .or(comment.createdAt.eq(cursorValue))
+            .and(comment.id.gt(cursorIdValue));
+    }
+
+    private BooleanExpression createForwardPredicate(UUID cursorId) {
+        Tuple cursor = getCursor(cursorId);
+
+        LocalDateTime cursorValue = cursor.get(comment.createdAt);
+        UUID cursorIdValue = cursor.get(comment.id);
+
+        return comment.createdAt.lt(cursorValue)
+            .or(comment.createdAt.eq(cursorValue))
+            .and(comment.id.lt(cursorIdValue));
+    }
+
+    private Tuple getCursor(UUID cursorId) {
+        return jpaQueryFactory
+            .select(comment.id, comment.createdAt)
+            .from(comment)
+            .where(comment.id.eq(cursorId))
+            .fetchFirst();
+    }
+}

--- a/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentRepository.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentRepository.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.example.entity.comment.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, UUID> {
+public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentQuerydslRepository {
 
     Optional<Comment> findByIdAndIsDeletedFalse(UUID commentId);
 }

--- a/app/domain/show-domain/src/main/java/org/example/usecase/CommentUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/CommentUseCase.java
@@ -3,8 +3,10 @@ package org.example.usecase;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.example.dto.comment.request.CommentPaginationDomainRequest;
 import org.example.dto.comment.request.CommentReportDomainRequest;
 import org.example.dto.comment.request.CommentWriteDomainRequest;
+import org.example.dto.comment.response.CommentPaginationDomainResponse;
 import org.example.entity.comment.Comment;
 import org.example.entity.comment.Report;
 import org.example.repository.comment.CommentRepository;
@@ -45,5 +47,9 @@ public class CommentUseCase {
     private Comment findComment(UUID commentId) {
         return commentRepository.findByIdAndIsDeletedFalse(commentId)
             .orElseThrow(NoSuchElementException::new);
+    }
+
+    public CommentPaginationDomainResponse findCommentsByPagination(CommentPaginationDomainRequest request) {
+        return commentRepository.findAllWithCursorPagination(request);
     }
 }

--- a/app/domain/show-domain/src/main/java/org/example/usecase/CommentUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/CommentUseCase.java
@@ -19,6 +19,7 @@ public class CommentUseCase {
     private final CommentRepository commentRepository;
     private final ReportRepository reportRepository;
 
+    @Transactional
     public void writeComment(CommentWriteDomainRequest request, UUID userId) {
         Comment comment = request.toComment(userId);
         commentRepository.save(comment);
@@ -30,7 +31,13 @@ public class CommentUseCase {
         comment.delete(userId);
     }
 
+    @Transactional
     public void reportComment(CommentReportDomainRequest request, UUID commentId, UUID userId) {
+        Comment comment = findComment(commentId);
+        if (comment.isWriter(userId)) {
+            throw new IllegalArgumentException();
+        }
+
         Report report = request.toReport(userId, commentId);
         reportRepository.save(report);
     }

--- a/app/domain/user-domain/src/main/java/org/example/usecase/UserUseCase.java
+++ b/app/domain/user-domain/src/main/java/org/example/usecase/UserUseCase.java
@@ -1,5 +1,6 @@
 package org.example.usecase;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -69,5 +70,9 @@ public class UserUseCase {
     @Transactional
     public void updateFcmToken(User user, String fcmToken) {
         user.updateFcmToken(fcmToken);
+    }
+
+    public List<User> findAllByUserIds(List<UUID> userId) {
+        return userRepository.findAllById(userId);
     }
 }

--- a/app/domain/user-domain/src/main/java/org/example/usecase/UserUseCase.java
+++ b/app/domain/user-domain/src/main/java/org/example/usecase/UserUseCase.java
@@ -72,7 +72,7 @@ public class UserUseCase {
         user.updateFcmToken(fcmToken);
     }
 
-    public List<User> findAllByUserIds(List<UUID> userId) {
-        return userRepository.findAllById(userId);
+    public List<User> findAllByUserIds(List<UUID> userIds) {
+        return userRepository.findAllById(userIds);
     }
 }


### PR DESCRIPTION
## 😋 작업한 내용

- SecurityConfig에 API 접근제한 설정
- Figma에 보면, 신고 시 직접 입력 칸이 있으므로, 스키마 변경
- 댓글 삭제 및 신고/차단 시 예외처리 추가
- 댓글 목록 조회 API 구현

## 🙏 PR Point

- 직접 입력 (테이블 필드명) 명 괜찮은지 봐주세용

## 👍 관련 이슈

- Resolved : #57 


---