### PR TITLE
fix: 공연 댓글 목록 쿼리 수정

### DIFF
--- a/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentQuerydslRepositoryImpl.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/comment/CommentQuerydslRepositoryImpl.java
@@ -66,18 +66,18 @@ public class CommentQuerydslRepositoryImpl implements CommentQuerydslRepository 
             return wherePredicate;
         }
 
-        if (request.isInverted()) {
-            return wherePredicate.and(createInvertedPredicate(request.cursorId()));
+        if (!request.isInverted()) {
+            return wherePredicate.and(createRecentPredicate(request.cursorId()));
         }
 
-        return wherePredicate.and(createForwardPredicate(request.cursorId()));
+        return wherePredicate.and(createPastPredicate(request.cursorId()));
     }
 
     private BooleanExpression getDefaultPredicateExpression(CommentType commentType, UUID refId) {
         return comment.commentType.eq(commentType).and(comment.refId.eq(refId));
     }
 
-    private BooleanExpression createInvertedPredicate(UUID cursorId) {
+    private BooleanExpression createRecentPredicate(UUID cursorId) {
         Tuple cursor = getCursor(cursorId);
 
         LocalDateTime cursorValue = cursor.get(comment.createdAt);
@@ -88,7 +88,7 @@ public class CommentQuerydslRepositoryImpl implements CommentQuerydslRepository 
             .and(comment.id.gt(cursorIdValue));
     }
 
-    private BooleanExpression createForwardPredicate(UUID cursorId) {
+    private BooleanExpression createPastPredicate(UUID cursorId) {
         Tuple cursor = getCursor(cursorId);
 
         LocalDateTime cursorValue = cursor.get(comment.createdAt);


### PR DESCRIPTION
## 😋 작업한 내용

- 쿼리스트링에서 isInverted에 따른 쿼리 데이터 조회 순서 변경 
- isInverted : fasle -> 최신 데이터
-  isInverted : true -> 과거 데이터

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #


---